### PR TITLE
Add "roles/orgpolicy.policyViewer" to get rid of permission warnings

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -55,6 +55,7 @@ locals {
     "roles/cloudsql.viewer",
     "roles/compute.networkViewer",
     "roles/iam.securityReviewer",
+    "roles/orgpolicy.policyViewer",
     "roles/servicemanagement.quotaViewer",
     "roles/serviceusage.serviceUsageConsumer",
   ]


### PR DESCRIPTION
Add "roles/orgpolicy.policyViewer" to get rid of permission warnings